### PR TITLE
feat: term 순서 추가 및 조회 response 변경 (MZ-295)

### DIFF
--- a/api/src/main/kotlin/com/oksusu/susu/api/term/application/TermService.kt
+++ b/api/src/main/kotlin/com/oksusu/susu/api/term/application/TermService.kt
@@ -25,8 +25,8 @@ class TermService(
 
     suspend fun getAllActiveTerms(): List<Term> {
         return withMDCContext(Dispatchers.IO) {
-            termRepository.findAllByIsActiveOrderByIsEssentialDesc(true)
-        }
+            termRepository.findAllByIsActive(true)
+        }.sortedBy { term -> term.seq }
     }
 
     suspend fun validateExistTerms(ids: List<Long>) {

--- a/api/src/main/kotlin/com/oksusu/susu/api/term/model/response/GetTermInfosResponse.kt
+++ b/api/src/main/kotlin/com/oksusu/susu/api/term/model/response/GetTermInfosResponse.kt
@@ -9,13 +9,16 @@ data class GetTermInfosResponse(
     val title: String,
     /** 필수 동의 여부 / 필수 : 1, 선택 : 0 */
     val isEssential: Boolean,
+    /** 세부 사항 포함 여부 / 포함 : 1, 미포함 : 0 */
+    val isIncludeDetail: Boolean,
 ) {
     companion object {
         fun from(term: Term): GetTermInfosResponse {
             return GetTermInfosResponse(
                 id = term.id,
                 title = term.title,
-                isEssential = term.isEssential
+                isEssential = term.isEssential,
+                isIncludeDetail = term.description?.let { true } ?: false
             )
         }
     }

--- a/api/src/main/kotlin/com/oksusu/susu/api/term/model/response/GetTermResponse.kt
+++ b/api/src/main/kotlin/com/oksusu/susu/api/term/model/response/GetTermResponse.kt
@@ -17,7 +17,7 @@ data class GetTermResponse(
             return GetTermResponse(
                 id = term.id,
                 title = term.title,
-                description = term.description,
+                description = term.description ?: "",
                 isEssential = term.isEssential
             )
         }

--- a/domain/src/main/kotlin/com/oksusu/susu/domain/term/domain/Term.kt
+++ b/domain/src/main/kotlin/com/oksusu/susu/domain/term/domain/Term.kt
@@ -20,7 +20,10 @@ class Term(
     val title: String,
 
     /** 약관 내용 */
-    val description: String,
+    val description: String?,
+
+    /** 약관 순서 */
+    val seq: Int,
 
     /** 필수 동의 여부 / 필수 : 1, 선택 : 0 */
     @Column(name = "is_essential")

--- a/domain/src/main/kotlin/com/oksusu/susu/domain/term/infrastructure/TermRepository.kt
+++ b/domain/src/main/kotlin/com/oksusu/susu/domain/term/infrastructure/TermRepository.kt
@@ -8,7 +8,7 @@ import org.springframework.transaction.annotation.Transactional
 @Repository
 interface TermRepository : JpaRepository<Term, Long> {
     @Transactional(readOnly = true)
-    fun findAllByIsActiveOrderByIsEssentialDesc(isActive: Boolean): List<Term>
+    fun findAllByIsActive(isActive: Boolean): List<Term>
 
     @Transactional(readOnly = true)
     fun countAllByIdIn(ids: List<Long>): Long

--- a/scripts/DDL.sql
+++ b/scripts/DDL.sql
@@ -236,6 +236,8 @@ CREATE TABLE `term`
     `modified_at`  datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정일',
     PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT ='약관 정보';
+ALTER TABLE term ADD (`seq` int NOT NULL COMMENT '노출 순서');
+ALTER TABLE term MODIFY `description` text NULL;
 
 -- 약관 정보 동의
 CREATE TABLE `term_agreement`


### PR DESCRIPTION
## 작업사항
- term에 seq 추가했습니다

## 변경로직
- term 전체 조회시, seq로 정렬되도록 했습니다.
- term description nullable하게 바꿨습니다.
