### PR TITLE
fix: cowebfilter와 continuationInterceptor를 이용한 코루틴 내부 MDC 전파 구현

### DIFF
--- a/common/src/main/kotlin/com/oksusu/susu/common/coroutine/CoMdcFilter.kt
+++ b/common/src/main/kotlin/com/oksusu/susu/common/coroutine/CoMdcFilter.kt
@@ -1,0 +1,18 @@
+package com.oksusu.susu.common.coroutine
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.slf4j.MDCContext
+import kotlinx.coroutines.withContext
+import org.springframework.stereotype.Component
+import org.springframework.web.server.CoWebFilter
+import org.springframework.web.server.CoWebFilterChain
+import org.springframework.web.server.ServerWebExchange
+
+@Component
+class CoMdcFilter : CoWebFilter() {
+    override suspend fun filter(exchange: ServerWebExchange, chain: CoWebFilterChain) {
+        withContext(Dispatchers.Unconfined + MDCContext() + MdcContinuationInterceptor()) {
+            chain.filter(exchange)
+        }
+    }
+}

--- a/common/src/main/kotlin/com/oksusu/susu/common/coroutine/MdcContinuationInterceptor.kt
+++ b/common/src/main/kotlin/com/oksusu/susu/common/coroutine/MdcContinuationInterceptor.kt
@@ -1,0 +1,32 @@
+package com.oksusu.susu.common.coroutine
+
+import com.oksusu.susu.common.consts.MDC_KEY_TRACE_ID
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.reactor.ReactorContext
+import org.slf4j.MDC
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.CoroutineContext
+
+class MdcContinuationInterceptor : ContinuationInterceptor {
+    val logger = KotlinLogging.logger { }
+
+    override val key: CoroutineContext.Key<*>
+        get() = ContinuationInterceptor
+
+    override fun <T> interceptContinuation(continuation: Continuation<T>): Continuation<T> {
+        return MdcContinuationInterceptor(continuation)
+    }
+
+    class MdcContinuationInterceptor<T>(private val continuation: Continuation<T>) : Continuation<T> {
+        override val context: CoroutineContext
+            get() = continuation.context
+
+        override fun resumeWith(result: Result<T>) {
+            continuation.context[ReactorContext]?.context?.get<String>(MDC_KEY_TRACE_ID)?.run {
+                MDC.put(MDC_KEY_TRACE_ID, this)
+            }
+            continuation.resumeWith(result)
+        }
+    }
+}

--- a/common/src/main/kotlin/com/oksusu/susu/common/coroutine/MdcContinuationInterceptor.kt
+++ b/common/src/main/kotlin/com/oksusu/susu/common/coroutine/MdcContinuationInterceptor.kt
@@ -1,7 +1,6 @@
 package com.oksusu.susu.common.coroutine
 
 import com.oksusu.susu.common.consts.MDC_KEY_TRACE_ID
-import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.reactor.ReactorContext
 import org.slf4j.MDC
 import kotlin.coroutines.Continuation
@@ -9,8 +8,6 @@ import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
 
 class MdcContinuationInterceptor : ContinuationInterceptor {
-    val logger = KotlinLogging.logger { }
-
     override val key: CoroutineContext.Key<*>
         get() = ContinuationInterceptor
 

--- a/common/src/main/kotlin/com/oksusu/susu/common/extension/CoroutineExtension.kt
+++ b/common/src/main/kotlin/com/oksusu/susu/common/extension/CoroutineExtension.kt
@@ -15,8 +15,7 @@ suspend fun <T> withMDCContext(
     context: CoroutineContext = Dispatchers.IO,
     block: suspend () -> T,
 ): T {
-    val contextMap = MDC.getCopyOfContextMap() ?: emptyMap()
-    return withContext(context + MDCContext(contextMap) + MdcContinuationInterceptor()) { block() }
+    return withContext(context + MdcContinuationInterceptor()) { block() }
 }
 
 suspend fun <T> withJob(
@@ -39,7 +38,7 @@ suspend inline fun <A, B, C> parZipWithMDC(
     crossinline f: suspend CoroutineScope.(A, B) -> C,
 ): C {
     val contextMap = MDC.getCopyOfContextMap() ?: emptyMap()
-    val ctx = Dispatchers.Default + MDCContext(contextMap) + MdcContinuationInterceptor()
+    val ctx = Dispatchers.IO + MDCContext(contextMap) + MdcContinuationInterceptor()
     return parZip(ctx, fa, fb, f)
 }
 
@@ -50,7 +49,7 @@ suspend inline fun <A, B, C, D> parZipWithMDC(
     crossinline f: suspend CoroutineScope.(A, B, C) -> D,
 ): D {
     val contextMap = MDC.getCopyOfContextMap() ?: emptyMap()
-    val ctx = Dispatchers.Default + MDCContext(contextMap) + MdcContinuationInterceptor()
+    val ctx = Dispatchers.IO + MDCContext(contextMap) + MdcContinuationInterceptor()
     return parZip(ctx, fa, fb, fc, f)
 }
 
@@ -62,7 +61,7 @@ suspend inline fun <A, B, C, D, E> parZipWithMDC(
     crossinline f: suspend CoroutineScope.(A, B, C, D) -> E,
 ): E {
     val contextMap = MDC.getCopyOfContextMap() ?: emptyMap()
-    val ctx = Dispatchers.Default + MDCContext(contextMap) + MdcContinuationInterceptor()
+    val ctx = Dispatchers.IO + MDCContext(contextMap) + MdcContinuationInterceptor()
     return parZip(ctx, fa, fb, fc, fd, f)
 }
 
@@ -75,7 +74,7 @@ suspend inline fun <A, B, C, D, E, F> parZipWithMDC(
     crossinline f: suspend CoroutineScope.(A, B, C, D, E) -> F,
 ): F {
     val contextMap = MDC.getCopyOfContextMap() ?: emptyMap()
-    val ctx = Dispatchers.Default + MDCContext(contextMap) + MdcContinuationInterceptor()
+    val ctx = Dispatchers.IO + MDCContext(contextMap) + MdcContinuationInterceptor()
     return parZip(ctx, fa, fb, fc, fd, fe, f)
 }
 
@@ -89,7 +88,7 @@ suspend inline fun <A, B, C, D, E, F, G> parZipWithMDC(
     crossinline f: suspend CoroutineScope.(A, B, C, D, E, F) -> G,
 ): G {
     val contextMap = MDC.getCopyOfContextMap() ?: emptyMap()
-    val ctx = Dispatchers.Default + MDCContext(contextMap) + MdcContinuationInterceptor()
+    val ctx = Dispatchers.IO + MDCContext(contextMap) + MdcContinuationInterceptor()
     return parZip(ctx, fa, fb, fc, fd, fe, ff, f)
 }
 
@@ -104,7 +103,7 @@ suspend inline fun <A, B, C, D, E, F, G, H> parZipWithMDC(
     crossinline f: suspend CoroutineScope.(A, B, C, D, E, F, G) -> H,
 ): H {
     val contextMap = MDC.getCopyOfContextMap() ?: emptyMap()
-    val ctx = Dispatchers.Default + MDCContext(contextMap) + MdcContinuationInterceptor()
+    val ctx = Dispatchers.IO + MDCContext(contextMap) + MdcContinuationInterceptor()
     return parZip(ctx, fa, fb, fc, fd, fe, ff, fg, f)
 }
 
@@ -120,6 +119,6 @@ suspend inline fun <A, B, C, D, E, F, G, H, I> parZipWithMDC(
     crossinline f: suspend CoroutineScope.(A, B, C, D, E, F, G, H) -> I,
 ): I {
     val contextMap = MDC.getCopyOfContextMap() ?: emptyMap()
-    val ctx = Dispatchers.Default + MDCContext(contextMap) + MdcContinuationInterceptor()
+    val ctx = Dispatchers.IO + MDCContext(contextMap) + MdcContinuationInterceptor()
     return parZip(ctx, fa, fb, fc, fd, fe, ff, fg, fh, f)
 }

--- a/common/src/main/kotlin/com/oksusu/susu/common/extension/CoroutineExtension.kt
+++ b/common/src/main/kotlin/com/oksusu/susu/common/extension/CoroutineExtension.kt
@@ -2,6 +2,7 @@ package com.oksusu.susu.common.extension
 
 import arrow.fx.coroutines.parZip
 import com.oksusu.susu.common.consts.MDC_KEY_TRACE_ID
+import com.oksusu.susu.common.coroutine.MdcContinuationInterceptor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -15,7 +16,7 @@ suspend fun <T> withMDCContext(
     block: suspend () -> T,
 ): T {
     val contextMap = MDC.getCopyOfContextMap() ?: emptyMap()
-    return withContext(context + MDCContext(contextMap)) { block() }
+    return withContext(context + MDCContext(contextMap) + MdcContinuationInterceptor()) { block() }
 }
 
 suspend fun <T> withJob(
@@ -29,7 +30,7 @@ suspend fun <T> withJob(
 fun mdcCoroutineScope(context: CoroutineContext, traceId: String): CoroutineScope {
     val contextMap = MDC.getCopyOfContextMap() ?: emptyMap()
     contextMap.plus(MDC_KEY_TRACE_ID to traceId)
-    return CoroutineScope(context + MDCContext(contextMap))
+    return CoroutineScope(context + MDCContext(contextMap) + MdcContinuationInterceptor())
 }
 
 suspend inline fun <A, B, C> parZipWithMDC(
@@ -38,7 +39,7 @@ suspend inline fun <A, B, C> parZipWithMDC(
     crossinline f: suspend CoroutineScope.(A, B) -> C,
 ): C {
     val contextMap = MDC.getCopyOfContextMap() ?: emptyMap()
-    val ctx = Dispatchers.Default + MDCContext(contextMap)
+    val ctx = Dispatchers.Default + MDCContext(contextMap) + MdcContinuationInterceptor()
     return parZip(ctx, fa, fb, f)
 }
 
@@ -49,7 +50,7 @@ suspend inline fun <A, B, C, D> parZipWithMDC(
     crossinline f: suspend CoroutineScope.(A, B, C) -> D,
 ): D {
     val contextMap = MDC.getCopyOfContextMap() ?: emptyMap()
-    val ctx = Dispatchers.Default + MDCContext(contextMap)
+    val ctx = Dispatchers.Default + MDCContext(contextMap) + MdcContinuationInterceptor()
     return parZip(ctx, fa, fb, fc, f)
 }
 
@@ -61,7 +62,7 @@ suspend inline fun <A, B, C, D, E> parZipWithMDC(
     crossinline f: suspend CoroutineScope.(A, B, C, D) -> E,
 ): E {
     val contextMap = MDC.getCopyOfContextMap() ?: emptyMap()
-    val ctx = Dispatchers.Default + MDCContext(contextMap)
+    val ctx = Dispatchers.Default + MDCContext(contextMap) + MdcContinuationInterceptor()
     return parZip(ctx, fa, fb, fc, fd, f)
 }
 
@@ -74,7 +75,7 @@ suspend inline fun <A, B, C, D, E, F> parZipWithMDC(
     crossinline f: suspend CoroutineScope.(A, B, C, D, E) -> F,
 ): F {
     val contextMap = MDC.getCopyOfContextMap() ?: emptyMap()
-    val ctx = Dispatchers.Default + MDCContext(contextMap)
+    val ctx = Dispatchers.Default + MDCContext(contextMap) + MdcContinuationInterceptor()
     return parZip(ctx, fa, fb, fc, fd, fe, f)
 }
 
@@ -88,7 +89,7 @@ suspend inline fun <A, B, C, D, E, F, G> parZipWithMDC(
     crossinline f: suspend CoroutineScope.(A, B, C, D, E, F) -> G,
 ): G {
     val contextMap = MDC.getCopyOfContextMap() ?: emptyMap()
-    val ctx = Dispatchers.Default + MDCContext(contextMap)
+    val ctx = Dispatchers.Default + MDCContext(contextMap) + MdcContinuationInterceptor()
     return parZip(ctx, fa, fb, fc, fd, fe, ff, f)
 }
 
@@ -103,7 +104,7 @@ suspend inline fun <A, B, C, D, E, F, G, H> parZipWithMDC(
     crossinline f: suspend CoroutineScope.(A, B, C, D, E, F, G) -> H,
 ): H {
     val contextMap = MDC.getCopyOfContextMap() ?: emptyMap()
-    val ctx = Dispatchers.Default + MDCContext(contextMap)
+    val ctx = Dispatchers.Default + MDCContext(contextMap) + MdcContinuationInterceptor()
     return parZip(ctx, fa, fb, fc, fd, fe, ff, fg, f)
 }
 
@@ -119,6 +120,6 @@ suspend inline fun <A, B, C, D, E, F, G, H, I> parZipWithMDC(
     crossinline f: suspend CoroutineScope.(A, B, C, D, E, F, G, H) -> I,
 ): I {
     val contextMap = MDC.getCopyOfContextMap() ?: emptyMap()
-    val ctx = Dispatchers.Default + MDCContext(contextMap)
+    val ctx = Dispatchers.Default + MDCContext(contextMap) + MdcContinuationInterceptor()
     return parZip(ctx, fa, fb, fc, fd, fe, ff, fg, fh, f)
 }


### PR DESCRIPTION
## 작업사항
- 코루틴 초기 시작때 MDC 전파용 CountinuationInterceptor 를 CoWebfilter를 통해 전파했습니다.

## 변경로직
- parZipWithMdc의 dispatcher를 IO로 변경했습니다.
