### PR TITLE
refac: 수수 통계 배치 작업 개선

### DIFF
--- a/api/src/main/kotlin/com/oksusu/susu/api/dev/DevBatchResource.kt
+++ b/api/src/main/kotlin/com/oksusu/susu/api/dev/DevBatchResource.kt
@@ -52,4 +52,15 @@ class DevBatchResource(
             susuEnvelopeStatisticJob.refreshSusuEnvelopeStatistic()
         }
     }
+
+    /** 수수 통계 캐싱 데이터를 초기화합니다. */
+    @Operation(tags = [SwaggerTag.DEV_SWAGGER_TAG], summary = "refresh susu envelope statistic amount 호출")
+    @GetMapping("/refresh-susu-envelope-statistic-amount")
+    suspend fun refreshSusuEnvelopeStatisticAmount(
+        adminUser: AdminUser,
+    ) {
+        CoroutineScope(Dispatchers.IO).launch {
+            susuEnvelopeStatisticJob.refreshSusuEnvelopeStatisticAmount()
+        }
+    }
 }

--- a/batch/src/main/kotlin/com/oksusu/susu/batch/envelope/job/RefreshSusuEnvelopeStatisticJob.kt
+++ b/batch/src/main/kotlin/com/oksusu/susu/batch/envelope/job/RefreshSusuEnvelopeStatisticJob.kt
@@ -1,14 +1,13 @@
 package com.oksusu.susu.batch.envelope.job
 
+import com.oksusu.susu.cache.key.Cache
 import com.oksusu.susu.cache.key.CacheKeyGenerateHelper
+import com.oksusu.susu.cache.service.CacheService
 import com.oksusu.susu.cache.statistic.domain.SusuEnvelopeStatistic
 import com.oksusu.susu.cache.statistic.infrastructure.SusuEnvelopeStatisticRepository
 import com.oksusu.susu.cache.statistic.infrastructure.SusuSpecificEnvelopeStatisticRepository
 import com.oksusu.susu.common.config.SusuConfig
-import com.oksusu.susu.common.extension.parZipWithMDC
-import com.oksusu.susu.common.extension.toStatisticAgeGroup
-import com.oksusu.susu.common.extension.withMDCContext
-import com.oksusu.susu.common.extension.yearMonth
+import com.oksusu.susu.common.extension.*
 import com.oksusu.susu.common.model.TitleValueModel
 import com.oksusu.susu.domain.category.domain.Category
 import com.oksusu.susu.domain.category.infrastructure.CategoryRepository
@@ -17,16 +16,16 @@ import com.oksusu.susu.domain.envelope.infrastructure.EnvelopeRepository
 import com.oksusu.susu.domain.envelope.infrastructure.LedgerRepository
 import com.oksusu.susu.domain.envelope.infrastructure.model.CountAvgAmountPerStatisticGroupModel
 import com.oksusu.susu.domain.envelope.infrastructure.model.CountPerCategoryIdModel
+import com.oksusu.susu.domain.envelope.infrastructure.model.CountPerHandedOverAtModel
 import com.oksusu.susu.domain.friend.domain.Relationship
 import com.oksusu.susu.domain.friend.infrastructure.FriendRelationshipRepository
 import com.oksusu.susu.domain.friend.infrastructure.RelationshipRepository
 import com.oksusu.susu.domain.friend.infrastructure.model.CountPerRelationshipIdModel
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.*
 import org.springframework.stereotype.Component
 import java.time.LocalDate
+import java.time.LocalDateTime
 import kotlin.math.roundToLong
 
 @Component
@@ -40,18 +39,36 @@ class RefreshSusuEnvelopeStatisticJob(
     private val relationshipRepository: RelationshipRepository,
     private val statisticConfig: SusuConfig.StatisticConfig,
     private val adminUserConfig: SusuConfig.AdminUserConfig,
+    private val cacheService: CacheService,
 ) {
     private val logger = KotlinLogging.logger { }
 
-    suspend fun refreshSusuEnvelopeStatistic() {
-        logger.info { "start refresh susu statistic" }
+    companion object {
+        private const val REFRESH_BEFORE_HOURS = 1L
 
-        val (minAmount, maxAmount) = getMaxAndMinAmount() //
+        /** 월별 사용 총 금액 캐시 키 (1년) */
+        private const val MONTHLY_SPENT_ENVELOPE_AMOUNT_FOR_LAST_YEAR_PREFIX =
+            "monthly-spent-envelop-amount-for-last-year:"
+
+        /** 관계별 총합 캐시 키 */
+        private const val RELATIONSHIP_COUNT_PREFIX = "relationship_count:"
+
+        /** 경조사별 총 횟수 캐싱 */
+        private const val CATEGORY_COUNT_PREFIX = "category_count:"
+
+        /** 나이, 카테고리, 관계별 금액 총 합 및 개수*/
+        private const val SUSU_SPECIFIC_ENVELOPE_STATISTIC_AMOUNT_PREFIX = "susu_specific_envelope_statistic_amount:"
+        private const val SUSU_SPECIFIC_ENVELOPE_STATISTIC_COUNT_PREFIX = "susu_specific_envelope_statistic_count:"
+    }
+
+    suspend fun refreshSusuEnvelopeStatisticAmount() {
+        logger.info { "start refresh susu envelope statistic amount" }
+
+        val (minAmount, maxAmount) = getMaxAndMinAmount()
 
         val from = LocalDate.now().minusMonths(11).atTime(0, 0)
         val to = LocalDate.now().atTime(23, 59)
         parZipWithMDC(
-            { withContext(Dispatchers.IO) { envelopeRepository.getUserCountHadEnvelope() } },
             {
                 withContext(Dispatchers.IO) {
                     envelopeRepository.getCuttingTotalAmountPerHandedOverAtBetweenExceptUid(
@@ -75,13 +92,89 @@ class RefreshSusuEnvelopeStatisticJob(
                         adminUserConfig.adminUserUid
                     )
                 }
+            }
+        ) {
+                monthlySpentEnvelopAmountForLastYear,
+                relationShipConuts,
+                envelopeCategoryCounts,
+                ledgerCategoryCounts,
+                totalAmountModels,
+            ->
+            cacheAmountData(
+                monthlySpentEnvelopAmountForLastYear = monthlySpentEnvelopAmountForLastYear,
+                relationShipConuts = relationShipConuts,
+                envelopeCategoryCounts = envelopeCategoryCounts,
+                ledgerCategoryCounts = ledgerCategoryCounts,
+                totalAmountModels = totalAmountModels
+            )
+
+            logger.info { "finish refresh susu envelope statistic amount" }
+        }
+    }
+
+    suspend fun refreshSusuEnvelopeStatistic() {
+        logger.info { "start refresh susu statistic" }
+
+        val (minAmount, maxAmount) = getMaxAndMinAmount()
+
+        val targetDate = LocalDateTime.now().minusDays(REFRESH_BEFORE_HOURS)
+
+        val to = LocalDateTime.now()
+        parZipWithMDC(
+            { withContext(Dispatchers.IO) { cacheService.getOrNull(Cache.getSusuEnvelopeStatisticAmountCache()) } },
+            { withContext(Dispatchers.IO) { envelopeRepository.getUserCountHadEnvelope() } },
+            {
+                withContext(Dispatchers.IO) {
+                    envelopeRepository.getCuttingTotalAmountPerHandedOverAtBetweenExceptUid(
+                        type = EnvelopeType.SENT,
+                        from = targetDate,
+                        to = to,
+                        minAmount = minAmount,
+                        maxAmount = maxAmount,
+                        uid = adminUserConfig.adminUserUid
+                    )
+                }
+            },
+            {
+                withContext(Dispatchers.IO) {
+                    friendRelationshipRepository.countPerRelationshipIdExceptUidByCreatedAtAfter(
+                        uid = adminUserConfig.adminUserUid,
+                        targetDate = targetDate
+                    )
+                }
+            },
+            {
+                withContext(Dispatchers.IO) {
+                    envelopeRepository.countPerCategoryIdExceptUidByCreatedAtAfter(
+                        uid = adminUserConfig.adminUserUid,
+                        targetDate = targetDate
+                    )
+                }
+            },
+            {
+                withContext(Dispatchers.IO) {
+                    ledgerRepository.countPerCategoryIdExceptUidByCreatedAtAfter(
+                        uid = adminUserConfig.adminUserUid,
+                        targetDate = targetDate
+                    )
+                }
+            },
+            {
+                withContext(Dispatchers.IO) {
+                    envelopeRepository.getCuttingTotalAmountPerStatisticGroupExceptUidByCreatedAtAfter(
+                        min = minAmount,
+                        max = maxAmount,
+                        uid = adminUserConfig.adminUserUid,
+                        targetDate = targetDate
+                    )
+                }
             },
             { withContext(Dispatchers.IO) { relationshipRepository.findAllByIsActive(true) } },
             { withContext(Dispatchers.IO) { categoryRepository.findAllByIsActive(true) } }
         ) {
-                /** 봉투 소유 유저 수 */
+                cachedAmount,
                 totalUserCount,
-                envelopeHandOverAtMonthCount,
+                monthlySpentEnvelopAmountForLastYear,
                 relationShipConuts,
                 envelopeCategoryCounts,
                 ledgerCategoryCounts,
@@ -94,33 +187,45 @@ class RefreshSusuEnvelopeStatisticJob(
             val relationshipMap = relationships.associateBy { relationship -> relationship.id }
             val categoryMap = categories.associateBy { category -> category.id }
 
+            /** 캐시 값 분류 */
+            val monthlySpentCache =
+                cachedAmount!!.classifyKeyByPrefix(MONTHLY_SPENT_ENVELOPE_AMOUNT_FOR_LAST_YEAR_PREFIX)
+            val relationshipCache = cachedAmount.classifyKeyByPrefix(RELATIONSHIP_COUNT_PREFIX)
+            val categoryCache = cachedAmount.classifyKeyByPrefix(CATEGORY_COUNT_PREFIX)
+            val specificAmountCache = cachedAmount.classifyKeyByPrefix(SUSU_SPECIFIC_ENVELOPE_STATISTIC_AMOUNT_PREFIX)
+            val specificCountCache = cachedAmount.classifyKeyByPrefix(SUSU_SPECIFIC_ENVELOPE_STATISTIC_COUNT_PREFIX)
+
             /** 최근 사용 금액 1년 */
-            val recentSpent = envelopeHandOverAtMonthCount.takeIf { it.isNotEmpty() }
-                ?.map { count ->
-                    TitleValueModel(count.handedOverAtMonth.toString(), count.totalAmounts)
-                }?.sortedBy { model -> model.title }
+            val monthlySpent = monthlySpentEnvelopAmountForLastYear
+                .associate { spent -> spent.handedOverAtMonth.toString() to spent.totalAmounts }
+                .merge(monthlySpentCache)
+                .takeIf { it.isNotEmpty() }
+                ?.map { map -> TitleValueModel(map.key, map.value) }
+                ?.sortedBy { model -> model.title }
+
+            /** 경조사비 가장 많이 쓴 달 */
+            val mostSpentMonth = monthlySpent?.maxBy { model -> model.value }?.title?.substring(4)?.toLong()
 
             /** 최근 사용 금액 8달 */
-            val recentSpentForLast8Months = getRecentSpentForLast8Months(
-                recentSpent = recentSpent,
-                userCount = userCount
+            val monthlySpentForLast8Months = getMonthlySpentForLast8Months(
+                monthlySpent = monthlySpent,
+                userCount = userCount,
             )
 
             /** 최다 수수 관계 */
             val mostFrequentRelationShip = getMostFrequentRelationShip(
                 relationShipConuts = relationShipConuts,
-                relationships = relationshipMap
+                relationships = relationshipMap,
+                relationshipCache = relationshipCache,
             )
 
             /** 최다 수수 경조사 */
             val mostFrequentCategory = getMostFrequentCategory(
                 envelopeCategoryCounts = envelopeCategoryCounts,
                 ledgerCategoryCounts = ledgerCategoryCounts,
-                categories = categoryMap
+                categories = categoryMap,
+                categoryCache = categoryCache,
             )
-
-            /** 경조사비 가장 많이 쓴 달 */
-            val mostSpentMonth = recentSpent?.maxBy { model -> model.value }?.title?.substring(4)?.toLong()
 
             /** 최다 수수 경조사 평균 */
             val avgMostFrequentCategory = mostFrequentCategory?.apply { value /= userCount }
@@ -130,7 +235,7 @@ class RefreshSusuEnvelopeStatisticJob(
 
             susuEnvelopeStatisticRepository.save(
                 SusuEnvelopeStatistic(
-                    recentSpent = recentSpentForLast8Months,
+                    recentSpent = monthlySpentForLast8Months,
                     mostSpentMonth = mostSpentMonth,
                     mostFrequentCategory = avgMostFrequentCategory,
                     mostFrequentRelationShip = avgMostFrequentRelationship
@@ -138,14 +243,21 @@ class RefreshSusuEnvelopeStatisticJob(
             )
 
             /**  평균 수수 레디스 저장 key: age:categoryId:relationshipId, value: avg */
-            parseIntoGroup(totalAmountModels).map { model ->
-                async {
-                    susuSpecificEnvelopeStatisticRepository.save(
-                        CacheKeyGenerateHelper.getSusuSpecificStatisticKey(model.key),
-                        model.value
-                    )
-                }
+            val specificCache = mutableMapOf<String, Pair<Long, Long>>()
+
+            for ((key, value) in specificAmountCache) {
+                specificCache[key] = value to specificCountCache[key]!!
             }
+
+            parseIntoEnvelopeSpecificStatisticGroup(totalAmountModels).mergePair(specificCache)
+                .map { model ->
+                    async {
+                        susuSpecificEnvelopeStatisticRepository.save(
+                            CacheKeyGenerateHelper.getSusuSpecificStatisticKey(model.key),
+                            model.value.first / model.value.second
+                        )
+                    }
+                }
 
             /** key: susu_category_statistic:categoryId, value: avg */
             totalAmountModels.groupBy { it.categoryId }.map { modelsMap ->
@@ -169,7 +281,68 @@ class RefreshSusuEnvelopeStatisticJob(
                 async { susuSpecificEnvelopeStatisticRepository.save(key, avgAmount) }
             }
 
+            /** amount 값 캐싱 */
+            cacheAmountData(
+                monthlySpentEnvelopAmountForLastYear = monthlySpentEnvelopAmountForLastYear,
+                relationShipConuts = relationShipConuts,
+                envelopeCategoryCounts = envelopeCategoryCounts,
+                ledgerCategoryCounts = ledgerCategoryCounts,
+                totalAmountModels = totalAmountModels
+            )
+
             logger.info { "finish refresh susu statistic" }
+        }
+    }
+
+    private suspend fun cacheAmountData(
+        monthlySpentEnvelopAmountForLastYear: List<CountPerHandedOverAtModel>,
+        relationShipConuts: List<CountPerRelationshipIdModel>,
+        envelopeCategoryCounts: List<CountPerCategoryIdModel>,
+        ledgerCategoryCounts: List<CountPerCategoryIdModel>,
+        totalAmountModels: List<CountAvgAmountPerStatisticGroupModel>,
+    ) {
+        CoroutineScope(Dispatchers.IO).launch {
+            val cache = mutableMapOf<String, Long>()
+
+            /** 월별 사용 총 금액 캐싱 */
+            monthlySpentEnvelopAmountForLastYear.map { count ->
+                val key = "$MONTHLY_SPENT_ENVELOPE_AMOUNT_FOR_LAST_YEAR_PREFIX${count.handedOverAtMonth}"
+                cache[key] = count.totalAmounts
+            }
+
+            /** 나이, 카테고리, 관계별 금액 총 합 key: age:categoryId:relationshipId, value: avg */
+
+            /** 나이, 카테고리, 관계별 금액 총 합 key: age:categoryId:relationshipId, value: avg */
+            parseIntoEnvelopeSpecificStatisticGroup(totalAmountModels).map { model ->
+                val amountKey = "$SUSU_SPECIFIC_ENVELOPE_STATISTIC_AMOUNT_PREFIX${model.key}"
+                cache[amountKey] = model.value.first
+                val countKey = "$SUSU_SPECIFIC_ENVELOPE_STATISTIC_COUNT_PREFIX${model.key}"
+                cache[countKey] = model.value.second
+            }
+
+            /** 관계별 총 횟수 캐싱 */
+
+            /** 관계별 총 횟수 캐싱 */
+            relationShipConuts.map { relationship ->
+                val key = "$RELATIONSHIP_COUNT_PREFIX${relationship.relationshipId}"
+                cache[key] = relationship.totalCounts
+            }
+
+            /** 경조사별 총 횟수 캐싱 */
+
+            /** 경조사별 총 횟수 캐싱 */
+            envelopeCategoryCounts.map { category ->
+                val key = "$CATEGORY_COUNT_PREFIX${category.categoryId}"
+                val currentCount = cache[key] ?: 0
+                cache[key] = currentCount + category.totalCounts
+            }
+            ledgerCategoryCounts.map { category ->
+                val key = "$CATEGORY_COUNT_PREFIX${category.categoryId}"
+                val currentCount = cache[key] ?: 0
+                cache[key] = currentCount + category.totalCounts
+            }
+
+            withMDCContext(Dispatchers.IO) { cacheService.set(Cache.getSusuEnvelopeStatisticAmountCache(), cache) }
         }
     }
 
@@ -201,37 +374,31 @@ class RefreshSusuEnvelopeStatisticJob(
                 }
             }
         ) { min, max ->
-//            val minAmount = min.takeIf { it.isNotEmpty() }
-//                ?.first()?.amount
-//                ?: throw NotFoundException(ErrorCode.NOT_FOUND_ENVELOPE_ERROR)
-//            val maxAmount = max.takeIf { it.isNotEmpty() }
-//                ?.first()?.amount
-//                ?: throw NotFoundException(ErrorCode.NOT_FOUND_ENVELOPE_ERROR)
-//
-//            minAmount to maxAmount
             min to max
         }
     }
 
-    private fun getRecentSpentForLast8Months(
-        recentSpent: List<TitleValueModel<Long>>?,
+    private fun getMonthlySpentForLast8Months(
+        monthlySpent: List<TitleValueModel<Long>>?,
         userCount: Long,
     ): List<TitleValueModel<Long>>? {
         val before8Month = LocalDate.now().minusMonths(7).yearMonth()
-        return recentSpent?.filter { spent -> spent.title >= before8Month }
+        return monthlySpent?.filter { spent -> spent.title >= before8Month }
             ?.map { model -> model.apply { value /= userCount } }
     }
 
     private fun getMostFrequentRelationShip(
         relationShipConuts: List<CountPerRelationshipIdModel>,
         relationships: Map<Long, Relationship>,
+        relationshipCache: Map<String, Long>,
     ): TitleValueModel<Long>? {
-        return relationShipConuts.takeIf { it.isNotEmpty() }
-            ?.maxBy { it.totalCounts }
+        return relationShipConuts.associate { relationship -> relationship.relationshipId.toString() to relationship.totalCounts }
+            .merge(relationshipCache)
+            .maxByOrNull { map -> map.value }
             ?.run {
                 TitleValueModel(
-                    title = relationships[this.relationshipId]!!.relation,
-                    value = this.totalCounts
+                    title = relationships[this.key.toLong()]!!.relation,
+                    value = this.value
                 )
             }
     }
@@ -240,29 +407,28 @@ class RefreshSusuEnvelopeStatisticJob(
         envelopeCategoryCounts: List<CountPerCategoryIdModel>,
         ledgerCategoryCounts: List<CountPerCategoryIdModel>,
         categories: Map<Long, Category>,
+        categoryCache: Map<String, Long>,
     ): TitleValueModel<Long>? {
-        val categoryIdSet = envelopeCategoryCounts.map { count -> count.categoryId }.toSet()
-            .union(ledgerCategoryCounts.map { count -> count.categoryId })
-        val categoryCounts = categoryIdSet.map { id ->
-            val envelopeCount = envelopeCategoryCounts.firstOrNull { it.categoryId == id }
-                ?.totalCounts ?: 0L
-            val ledgerCount = ledgerCategoryCounts.firstOrNull { it.categoryId == id }
-                ?.totalCounts ?: 0L
-            CountPerCategoryIdModel(
-                categoryId = id,
-                totalCounts = envelopeCount + ledgerCount
-            )
+        val countMap = mutableMapOf<String, Long>()
+
+        envelopeCategoryCounts.map { category ->
+            val currentCount = countMap[category.categoryId.toString()] ?: 0
+            countMap[category.categoryId.toString()] = currentCount + category.totalCounts
+        }
+        ledgerCategoryCounts.map { category ->
+            val currentCount = countMap[category.categoryId.toString()] ?: 0
+            countMap[category.categoryId.toString()] = currentCount + category.totalCounts
         }
 
-        return categoryCounts.takeIf { it.isNotEmpty() }
-            ?.maxBy { it.totalCounts }
-            ?.let {
-                val category = categories[it.categoryId]
-                TitleValueModel(title = category!!.name, value = it.totalCounts)
+        return countMap.merge(categoryCache)
+            .maxByOrNull { it.value }
+            ?.run {
+                val category = categories[this.key.toLong()]
+                TitleValueModel(title = category!!.name, value = this.value)
             }
     }
 
-    private fun parseIntoGroup(totalAmountModels: List<CountAvgAmountPerStatisticGroupModel>): Map<String, Long> {
+    private fun parseIntoEnvelopeSpecificStatisticGroup(totalAmountModels: List<CountAvgAmountPerStatisticGroupModel>): Map<String, Pair<Long, Long>> {
         /** key: age, value: list<model> */
         val ages = totalAmountModels.groupBy { it.birth.toStatisticAgeGroup() }
 
@@ -288,7 +454,7 @@ class RefreshSusuEnvelopeStatisticJob(
         return groups.map { group ->
             val totalAmounts = group.value.sumOf { value -> value.totalAmounts }
             val totalCounts = group.value.sumOf { value -> value.counts }
-            group.key to totalAmounts / totalCounts
+            group.key to (totalAmounts to totalCounts)
         }.toMap()
     }
 }

--- a/batch/src/main/kotlin/com/oksusu/susu/batch/envelope/job/RefreshSusuEnvelopeStatisticJob.kt
+++ b/batch/src/main/kotlin/com/oksusu/susu/batch/envelope/job/RefreshSusuEnvelopeStatisticJob.kt
@@ -228,7 +228,7 @@ class RefreshSusuEnvelopeStatisticJob(
             val monthlySpent = getMonthlySpentForLastYear(
                 monthlySpentEnvelopAmountForLastYear = monthlySpentEnvelopAmountForLastYear,
                 monthlySpentCache = monthlySpentCache,
-                cache = cache,
+                cache = cache
             )
 
             /** 최근 사용 금액 8달 */
@@ -245,7 +245,7 @@ class RefreshSusuEnvelopeStatisticJob(
                 relationShipConuts = relationShipConuts,
                 relationships = relationshipMap,
                 relationshipCache = relationshipCache,
-                cache = cache,
+                cache = cache
             )
 
             /** 최다 수수 경조사 */
@@ -254,7 +254,7 @@ class RefreshSusuEnvelopeStatisticJob(
                 ledgerCategoryCounts = ledgerCategoryCounts,
                 categories = categoryMap,
                 categoryCache = categoryCache,
-                cache = cache,
+                cache = cache
             )
 
             /** 최다 수수 경조사 평균 */
@@ -281,7 +281,7 @@ class RefreshSusuEnvelopeStatisticJob(
 
             val sortTypeAmountsMap = parseIntoEnvelopeSpecificStatisticGroup(totalAmountModels).mergePair(specificCache)
 
-            sortTypeAmountsMap.map {map ->
+            sortTypeAmountsMap.map { map ->
                 async {
                     susuSpecificEnvelopeStatisticRepository.save(
                         CacheKeyGenerateHelper.getSusuSpecificStatisticKey(map.key),
@@ -303,7 +303,7 @@ class RefreshSusuEnvelopeStatisticJob(
                         categoryId = keys[1].toLong(),
                         relationshipId = keys[2].toLong(),
                         totalAmounts = model.value.first,
-                        counts = model.value.second,
+                        counts = model.value.second
                     )
                 }
 

--- a/batch/src/main/kotlin/com/oksusu/susu/batch/envelope/job/RefreshSusuEnvelopeStatisticJob.kt
+++ b/batch/src/main/kotlin/com/oksusu/susu/batch/envelope/job/RefreshSusuEnvelopeStatisticJob.kt
@@ -66,8 +66,8 @@ class RefreshSusuEnvelopeStatisticJob(
 
         val (minAmount, maxAmount) = getMaxAndMinAmount()
 
-        val from = LocalDate.now().minusMonths(11).atTime(0, 0)
-        val to = LocalDate.now().atTime(23, 59)
+        val from = LocalDateTime.now().minusMonths(12)
+        val to = LocalDateTime.now()
         parZipWithMDC(
             {
                 withContext(Dispatchers.IO) {
@@ -117,7 +117,7 @@ class RefreshSusuEnvelopeStatisticJob(
 
         val (minAmount, maxAmount) = getMaxAndMinAmount()
 
-        val targetDate = LocalDateTime.now().minusDays(REFRESH_BEFORE_HOURS)
+        val targetDate = LocalDateTime.now().minusHours(REFRESH_BEFORE_HOURS)
 
         val to = LocalDateTime.now()
         parZipWithMDC(
@@ -209,14 +209,14 @@ class RefreshSusuEnvelopeStatisticJob(
             /** 최근 사용 금액 8달 */
             val monthlySpentForLast8Months = getMonthlySpentForLast8Months(
                 monthlySpent = monthlySpent,
-                userCount = userCount,
+                userCount = userCount
             )
 
             /** 최다 수수 관계 */
             val mostFrequentRelationShip = getMostFrequentRelationShip(
                 relationShipConuts = relationShipConuts,
                 relationships = relationshipMap,
-                relationshipCache = relationshipCache,
+                relationshipCache = relationshipCache
             )
 
             /** 최다 수수 경조사 */
@@ -224,7 +224,7 @@ class RefreshSusuEnvelopeStatisticJob(
                 envelopeCategoryCounts = envelopeCategoryCounts,
                 ledgerCategoryCounts = ledgerCategoryCounts,
                 categories = categoryMap,
-                categoryCache = categoryCache,
+                categoryCache = categoryCache
             )
 
             /** 최다 수수 경조사 평균 */
@@ -311,8 +311,6 @@ class RefreshSusuEnvelopeStatisticJob(
             }
 
             /** 나이, 카테고리, 관계별 금액 총 합 key: age:categoryId:relationshipId, value: avg */
-
-            /** 나이, 카테고리, 관계별 금액 총 합 key: age:categoryId:relationshipId, value: avg */
             parseIntoEnvelopeSpecificStatisticGroup(totalAmountModels).map { model ->
                 val amountKey = "$SUSU_SPECIFIC_ENVELOPE_STATISTIC_AMOUNT_PREFIX${model.key}"
                 cache[amountKey] = model.value.first
@@ -321,14 +319,10 @@ class RefreshSusuEnvelopeStatisticJob(
             }
 
             /** 관계별 총 횟수 캐싱 */
-
-            /** 관계별 총 횟수 캐싱 */
             relationShipConuts.map { relationship ->
                 val key = "$RELATIONSHIP_COUNT_PREFIX${relationship.relationshipId}"
                 cache[key] = relationship.totalCounts
             }
-
-            /** 경조사별 총 횟수 캐싱 */
 
             /** 경조사별 총 횟수 캐싱 */
             envelopeCategoryCounts.map { category ->
@@ -349,9 +343,7 @@ class RefreshSusuEnvelopeStatisticJob(
     private suspend fun getMaxAndMinAmount(): Pair<Long, Long> {
         val susuEnvelopeConfig = statisticConfig.susuEnvelopeConfig
 
-        val count = withMDCContext(Dispatchers.IO) {
-            envelopeRepository.countExceptUid(adminUserConfig.adminUserUid)
-        }
+        val count = withMDCContext(Dispatchers.IO) { envelopeRepository.countExceptUid(adminUserConfig.adminUserUid) }
 
         val minIdx = (count * susuEnvelopeConfig.minCuttingAverage).roundToLong()
         val maxIdx = (count * susuEnvelopeConfig.maxCuttingAverage).roundToLong()
@@ -373,9 +365,7 @@ class RefreshSusuEnvelopeStatisticJob(
                     )
                 }
             }
-        ) { min, max ->
-            min to max
-        }
+        ) { min, max -> min to max }
     }
 
     private fun getMonthlySpentForLast8Months(
@@ -383,6 +373,7 @@ class RefreshSusuEnvelopeStatisticJob(
         userCount: Long,
     ): List<TitleValueModel<Long>>? {
         val before8Month = LocalDate.now().minusMonths(7).yearMonth()
+
         return monthlySpent?.filter { spent -> spent.title >= before8Month }
             ?.map { model -> model.apply { value /= userCount } }
     }

--- a/cache/src/main/kotlin/com/oksusu/susu/cache/key/Cache.kt
+++ b/cache/src/main/kotlin/com/oksusu/susu/cache/key/Cache.kt
@@ -4,10 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference
 import com.oksusu.susu.cache.model.OidcPublicKeysCacheModel
 import com.oksusu.susu.cache.model.SusuEnvelopeStatisticCacheModel
 import com.oksusu.susu.cache.model.UserEnvelopeStatisticCacheModel
-import com.oksusu.susu.common.consts.APPLE_OIDC_PUBLIC_KEY_KEY
-import com.oksusu.susu.common.consts.SUSU_ENVELOPE_STATISTIC_KEY
-import com.oksusu.susu.common.consts.SUSU_STATISTIC_TTL
-import com.oksusu.susu.common.consts.USER_STATISTIC_TTL
+import com.oksusu.susu.common.consts.*
 import com.oksusu.susu.common.util.toTypeReference
 import java.time.Duration
 
@@ -58,6 +55,15 @@ data class Cache<VALUE_TYPE>(
                 type = toTypeReference(),
                 duration = Duration.ofDays(7)
             )
+        }
+
+        fun getSusuEnvelopeStatisticAmountCache(): Cache<Map<String, Long>> {
+            return Cache(
+                key = SUSU_ENVELOPE_STATISTIC_AMOUNT_KEY,
+                type = toTypeReference(),
+                duration = Duration.ofDays(1).plusHours(1)
+            )
+
         }
     }
 }

--- a/cache/src/main/kotlin/com/oksusu/susu/cache/key/Cache.kt
+++ b/cache/src/main/kotlin/com/oksusu/susu/cache/key/Cache.kt
@@ -63,7 +63,6 @@ data class Cache<VALUE_TYPE>(
                 type = toTypeReference(),
                 duration = Duration.ofDays(1).plusHours(1)
             )
-
         }
     }
 }

--- a/common/src/main/kotlin/com/oksusu/susu/common/consts/SusuConsts.kt
+++ b/common/src/main/kotlin/com/oksusu/susu/common/consts/SusuConsts.kt
@@ -20,6 +20,8 @@ const val FAIL_TO_VALIDATE_MESSAGE = "fail to validate"
 const val APPLE_OIDC_PUBLIC_KEY_KEY = "apple_oidc_public_key"
 const val APPLE_OIDC_PUBLIC_KEY_TTL = 7
 
+const val SUSU_ENVELOPE_STATISTIC_AMOUNT_KEY = "susu_envelope_statistic_amount"
+
 const val KID = "kid"
 
 const val MDC_KEY_TRACE_ID = "traceId"

--- a/common/src/main/kotlin/com/oksusu/susu/common/extension/CoroutineExtension.kt
+++ b/common/src/main/kotlin/com/oksusu/susu/common/extension/CoroutineExtension.kt
@@ -117,3 +117,19 @@ suspend inline fun <A, B, C, D, E, F, G, H, I> parZipWithMDC(
     val ctx = MDCContext() + Dispatchers.IO
     return parZip(ctx, fa, fb, fc, fd, fe, ff, fg, fh, f)
 }
+
+suspend inline fun <A, B, C, D, E, F, G, H, I, J> parZipWithMDC(
+    crossinline fa: suspend CoroutineScope.() -> A,
+    crossinline fb: suspend CoroutineScope.() -> B,
+    crossinline fc: suspend CoroutineScope.() -> C,
+    crossinline fd: suspend CoroutineScope.() -> D,
+    crossinline fe: suspend CoroutineScope.() -> E,
+    crossinline ff: suspend CoroutineScope.() -> F,
+    crossinline fg: suspend CoroutineScope.() -> G,
+    crossinline fh: suspend CoroutineScope.() -> H,
+    crossinline fj: suspend CoroutineScope.() -> J,
+    crossinline f: suspend CoroutineScope.(A, B, C, D, E, F, G, H, J) -> I,
+): I {
+    val ctx = MDCContext() + Dispatchers.IO
+    return parZip(ctx, fa, fb, fc, fd, fe, ff, fg, fh, fj, f)
+}

--- a/common/src/main/kotlin/com/oksusu/susu/common/extension/MapExtension.kt
+++ b/common/src/main/kotlin/com/oksusu/susu/common/extension/MapExtension.kt
@@ -1,0 +1,50 @@
+package com.oksusu.susu.common.extension
+
+fun <T : Any> Map<T, Long>.merge(map: Map<T, Long>): Map<T, Long> {
+    val resultMap = mutableMapOf<T, Long>()
+
+    for ((key, value) in this) {
+        resultMap[key] = value
+    }
+
+    for ((key, value) in map) {
+        resultMap.merge(key, value) { oldValue, newValue ->
+            oldValue + newValue }
+    }
+
+    return resultMap
+}
+
+fun <T : Any> Map<T, Pair<Long, Long>>.mergePair(map: Map<T, Pair<Long, Long>>): Map<T, Pair<Long, Long>> {
+    val resultMap = mutableMapOf<T, Pair<Long, Long>>()
+
+    for ((key, value) in this) {
+        resultMap[key] = value
+    }
+
+    for ((key, value) in map) {
+        resultMap.merge(
+            key,
+            value
+        ) { oldValue, newValue -> oldValue.first + newValue.first to oldValue.second + newValue.second }
+    }
+
+    return resultMap
+}
+
+fun <T> Map<String, T>.classifyKeyByPrefix(prefix: String, removePrefix: Boolean = true): Map<String, T> {
+    val matchingPrefixMap = mutableMapOf<String, T>()
+
+    this.map { map ->
+        if (map.key.startsWith(prefix)) {
+            if (removePrefix) {
+                val newKey = map.key.removePrefix(prefix)
+                matchingPrefixMap[newKey] = map.value
+            } else {
+                matchingPrefixMap[map.key] = map.value
+            }
+        }
+    }
+
+    return matchingPrefixMap
+}

--- a/common/src/main/kotlin/com/oksusu/susu/common/extension/MapExtension.kt
+++ b/common/src/main/kotlin/com/oksusu/susu/common/extension/MapExtension.kt
@@ -9,7 +9,8 @@ fun <T : Any> Map<T, Long>.merge(map: Map<T, Long>): Map<T, Long> {
 
     for ((key, value) in map) {
         resultMap.merge(key, value) { oldValue, newValue ->
-            oldValue + newValue }
+            oldValue + newValue
+        }
     }
 
     return resultMap

--- a/domain/src/main/kotlin/com/oksusu/susu/domain/envelope/infrastructure/EnvelopeRepository.kt
+++ b/domain/src/main/kotlin/com/oksusu/susu/domain/envelope/infrastructure/EnvelopeRepository.kt
@@ -87,10 +87,28 @@ interface EnvelopeCustomRepository {
     fun countPerCategoryIdExceptUid(uid: List<Long>): List<CountPerCategoryIdModel>
 
     @Transactional(readOnly = true)
+    fun countPerCategoryIdExceptUidByCreatedAtAfter(
+        uid: List<Long>,
+        targetDate: LocalDateTime,
+    ): List<CountPerCategoryIdModel>
+
+    @Transactional(readOnly = true)
     fun countPerCategoryIdByUid(uid: Long): List<CountPerCategoryIdModel>
 
     @Transactional(readOnly = true)
-    fun getCuttingTotalAmountPerStatisticGroupExceptUid(min: Long, max: Long, uid: List<Long>): List<CountAvgAmountPerStatisticGroupModel>
+    fun getCuttingTotalAmountPerStatisticGroupExceptUid(
+        min: Long,
+        max: Long,
+        uid: List<Long>,
+    ): List<CountAvgAmountPerStatisticGroupModel>
+
+    @Transactional(readOnly = true)
+    fun getCuttingTotalAmountPerStatisticGroupExceptUidByCreatedAtAfter(
+        min: Long,
+        max: Long,
+        uid: List<Long>,
+        targetDate: LocalDateTime,
+    ): List<CountAvgAmountPerStatisticGroupModel>
 
     @Transactional(readOnly = true)
     fun search(spec: SearchEnvelopeSpec, pageable: Pageable): Page<Envelope>
@@ -262,6 +280,26 @@ class EnvelopeCustomRepositoryImpl : EnvelopeCustomRepository, QuerydslRepositor
             .fetch()
     }
 
+    override fun countPerCategoryIdExceptUidByCreatedAtAfter(
+        uid: List<Long>,
+        targetDate: LocalDateTime,
+    ): List<CountPerCategoryIdModel> {
+        return JPAQuery<Envelope>(entityManager)
+            .select(
+                QCountPerCategoryIdModel(
+                    qCategoryAssignment.categoryId,
+                    qEnvelope.id.count()
+                )
+            ).from(qEnvelope)
+            .join(qCategoryAssignment).on(qEnvelope.id.eq(qCategoryAssignment.targetId))
+            .where(
+                qEnvelope.ledgerId.isNull,
+                qEnvelope.uid.notIn(uid),
+                qEnvelope.createdAt.after(targetDate)
+            ).groupBy(qCategoryAssignment.categoryId)
+            .fetch()
+    }
+
     override fun countPerCategoryIdByUid(uid: Long): List<CountPerCategoryIdModel> {
         return JPAQuery<Envelope>(entityManager)
             .select(
@@ -300,6 +338,37 @@ class EnvelopeCustomRepositoryImpl : EnvelopeCustomRepository, QuerydslRepositor
             .where(
                 qEnvelope.amount.between(minAmount, maxAmount),
                 qEnvelope.uid.notIn(uid)
+            )
+            .groupBy(
+                qCategoryAssignment.categoryId,
+                qUser.birth.year().castToNum(Long::class.java),
+                qFriendRelationship.relationshipId
+            ).fetch()
+    }
+
+    override fun getCuttingTotalAmountPerStatisticGroupExceptUidByCreatedAtAfter(
+        minAmount: Long,
+        maxAmount: Long,
+        uid: List<Long>,
+        targetDate: LocalDateTime,
+    ): List<CountAvgAmountPerStatisticGroupModel> {
+        return JPAQuery<Envelope>(entityManager)
+            .select(
+                QCountAvgAmountPerStatisticGroupModel(
+                    qCategoryAssignment.categoryId,
+                    qFriendRelationship.relationshipId,
+                    qUser.birth.year().castToNum(Long::class.java),
+                    qEnvelope.amount.sum(),
+                    qEnvelope.id.count()
+                )
+            ).from(qEnvelope)
+            .join(qUser).on(qEnvelope.uid.eq(qUser.id))
+            .join(qFriendRelationship).on(qEnvelope.friendId.eq(qFriendRelationship.friendId))
+            .join(qCategoryAssignment).on(qEnvelope.id.eq(qCategoryAssignment.targetId))
+            .where(
+                qEnvelope.amount.between(minAmount, maxAmount),
+                qEnvelope.uid.notIn(uid),
+                qEnvelope.createdAt.after(targetDate)
             )
             .groupBy(
                 qCategoryAssignment.categoryId,

--- a/domain/src/main/kotlin/com/oksusu/susu/domain/envelope/infrastructure/LedgerRepository.kt
+++ b/domain/src/main/kotlin/com/oksusu/susu/domain/envelope/infrastructure/LedgerRepository.kt
@@ -44,6 +44,12 @@ interface LedgerCustomRepository {
     fun countPerCategoryIdExceptUid(uid: List<Long>): List<CountPerCategoryIdModel>
 
     @Transactional(readOnly = true)
+    fun countPerCategoryIdExceptUidByCreatedAtAfter(
+        uid: List<Long>,
+        targetDate: LocalDateTime,
+    ): List<CountPerCategoryIdModel>
+
+    @Transactional(readOnly = true)
     fun countPerCategoryIdByUid(uid: Long): List<CountPerCategoryIdModel>
 }
 
@@ -115,6 +121,27 @@ class LedgerCustomRepositoryImpl : LedgerCustomRepository, QuerydslRepositorySup
             .join(qCategoryAssignment).on(qLedger.id.eq(qCategoryAssignment.targetId))
             .where(
                 qLedger.uid.notIn(uid)
+            )
+            .groupBy(qCategoryAssignment.categoryId)
+            .fetch()
+    }
+
+    override fun countPerCategoryIdExceptUidByCreatedAtAfter(
+        uid: List<Long>,
+        targetDate: LocalDateTime,
+    ): List<CountPerCategoryIdModel> {
+        return JPAQuery<QLedger>(entityManager)
+            .select(
+                QCountPerCategoryIdModel(
+                    qCategoryAssignment.categoryId,
+                    qLedger.id.count()
+                )
+            )
+            .from(qLedger)
+            .join(qCategoryAssignment).on(qLedger.id.eq(qCategoryAssignment.targetId))
+            .where(
+                qLedger.uid.notIn(uid),
+                qLedger.createdAt.after(targetDate)
             )
             .groupBy(qCategoryAssignment.categoryId)
             .fetch()


### PR DESCRIPTION
## 작업사항
- 기존 1년치 데이터 쿼리하는 로직에서 1일 데이터만 쿼리하고 나머지 데이터는 캐싱하는 방식으로 변경함

## 변경로직
- 오래된 데이터는 캐싱하는 방식 도입

+ 평균 이상한 것 같으면 강제 초기화 하면 됨 api 만들어듐
