### PR TITLE
refac: lock 로직 리팩토링 (MZ-308)

### DIFF
--- a/api/src/main/kotlin/com/oksusu/susu/api/common/lock/LockManager.kt
+++ b/api/src/main/kotlin/com/oksusu/susu/api/common/lock/LockManager.kt
@@ -1,5 +1,8 @@
 package com.oksusu.susu.api.common.lock
 
 interface LockManager {
+    /**
+     * 서비스 로직 (block)에 key를 이용하여 락을 설정한 후 실행한다.
+     */
     suspend fun <T> lock(key: String, block: suspend () -> T): T
 }

--- a/api/src/main/kotlin/com/oksusu/susu/api/common/lock/SuspendableLockManager.kt
+++ b/api/src/main/kotlin/com/oksusu/susu/api/common/lock/SuspendableLockManager.kt
@@ -13,45 +13,51 @@ import java.time.LocalDateTime
 
 private val logger = KotlinLogging.logger { }
 
-private const val WAIT_TIME = 1000L
-private const val LEASE_TIME = 3000L
-private const val WAIT_TIME_SECONDS = WAIT_TIME * 1000
-private const val LEASE_TIME_SECONDS = LEASE_TIME * 1000
-
+private const val WAIT_TIME_MILLI = 1000L
+private const val LEASE_TIME_MILLI = 3000L
+private const val WAIT_TIME_SECONDS = WAIT_TIME_MILLI / 1000
+private const val LEASE_TIME_SECONDS = LEASE_TIME_MILLI / 1000
 
 private sealed class LockMsg {
-    /** 락 획득 시도 */
+    /** 락 설정 */
     class Lock(
         val requestTime: LocalDateTime,
         val block: suspend () -> Any?,
-        val blockResult: CompletableDeferred<Any?>,
+        val result: CompletableDeferred<Any?>,
     ) : LockMsg()
 
+    /** 엑터의 채널이 비었는지 확인 */
     class IsEmpty(
         val result: CompletableDeferred<Boolean>,
     ) : LockMsg()
 }
 
-@OptIn(ObsoleteCoroutinesApi::class)
+/**
+ * 특정 키에 해당된 작업을 순차적으로 수행하는 actor
+ * msg가 실행된다 == 락을 획득했다 로 여김
+ */
+@OptIn(ObsoleteCoroutinesApi::class, ExperimentalCoroutinesApi::class)
 private fun lockActor() = CoroutineScope(Dispatchers.IO).actor<LockMsg>(capacity = 1000) {
     for (msg in channel) {
         when (msg) {
             is LockMsg.Lock -> {
                 if (msg.requestTime.isBefore(LocalDateTime.now().minusSeconds(WAIT_TIME_SECONDS))) {
-                    msg.blockResult.complete(FailToExecuteException(ErrorCode.ACQUIRE_LOCK_TIMEOUT))
+                    // 락은 획득했지만 락 획득 시간보다 더 오랜 시간이 걸렸다면 timeout 에러 발생
+                    msg.result.complete(FailToExecuteException(ErrorCode.ACQUIRE_LOCK_TIMEOUT))
                 } else {
                     try {
-                        withTimeout(LEASE_TIME) {
+                        // 로직 실행 및 deferred에 결과값 넣기
+                        withTimeout(LEASE_TIME_MILLI) {
                             val rtn = msg.block()
 
-                            msg.blockResult.complete(rtn)
+                            msg.result.complete(rtn)
                         }
                     } catch (e: TimeoutCancellationException) {
                         // 락 획득 시간 에러 처리
-                        msg.blockResult.complete(FailToExecuteException(ErrorCode.LOCK_TIMEOUT_ERROR))
+                        msg.result.complete(FailToExecuteException(ErrorCode.LOCK_TIMEOUT_ERROR))
                     } catch (e: Exception) {
                         // 이외의 에러 처리
-                        msg.blockResult.complete(FailToExecuteException(ErrorCode.FAIL_TO_EXECUTE_LOCK))
+                        msg.result.complete(e)
                     }
                 }
             }
@@ -64,17 +70,21 @@ private fun lockActor() = CoroutineScope(Dispatchers.IO).actor<LockMsg>(capacity
 }
 
 private sealed class LockManagerMsg {
-    /** 락 획득 시도 */
+    /** 락 시도 */
     class TryLock(
-        val requestTime: LocalDateTime,
+        val requestTime: LocalDateTime = LocalDateTime.now(),
         val key: String,
         val block: suspend () -> Any?,
-        val blockResult: CompletableDeferred<Any?>,
+        val result: CompletableDeferred<Any?>,
     ) : LockManagerMsg()
 
+    /** 미사용 엑터 삭제 */
     class ClearActor : LockManagerMsg()
 }
 
+/**
+ * 키에 해당하는 actor에 요청을 보내는 역할을 하는 actor
+ */
 @OptIn(ObsoleteCoroutinesApi::class)
 private fun lockManagerActor() = CoroutineScope(Dispatchers.IO).actor<LockManagerMsg>(capacity = 1000) {
     val actorMap = HashMap<String, SendChannel<LockMsg>>()
@@ -82,89 +92,114 @@ private fun lockManagerActor() = CoroutineScope(Dispatchers.IO).actor<LockManage
     for (msg in channel) {
         when (msg) {
             is LockManagerMsg.TryLock -> {
-                logger.info { "${msg.requestTime} ${LocalDateTime.now()}" }
                 if (msg.requestTime.isBefore(LocalDateTime.now().minusSeconds(WAIT_TIME_SECONDS))) {
-                    msg.blockResult.complete(FailToExecuteException(ErrorCode.ACQUIRE_LOCK_TIMEOUT))
+                    // 락 획득 시간보다 더 오랜 시간이 걸렸다면 timeout 에러 발생
+                    msg.result.complete(FailToExecuteException(ErrorCode.ACQUIRE_LOCK_TIMEOUT))
                 } else {
                     try {
+                        // actor 가져오기
                         val actor = actorMap.computeIfAbsent(msg.key) { _ -> lockActor() }
 
+                        // 락 처리 요청
                         actor.send(
                             LockMsg.Lock(
                                 requestTime = LocalDateTime.now(),
                                 block = msg.block,
-                                blockResult = msg.blockResult,
+                                result = msg.result
                             )
                         )
                     } catch (e: Exception) {
-                        msg.blockResult.complete(FailToExecuteException(ErrorCode.FAIL_TO_GET_LOCK))
+                        msg.result.complete(e)
                     }
                 }
             }
 
             is LockManagerMsg.ClearActor -> {
-                logger.info { "before ${actorMap}" }
+                logger.info { "before $actorMap" }
 
-                val deferreds = actorMap.entries.map { (key, actor) ->
-                    async {
-                        val result = CompletableDeferred<Boolean>()
+                // actor channel 비었는지 조회
+                actorMap.entries.chunked(100).map { actors ->
+                    val deferreds = actors.map { (key, actor) ->
+                        async {
+                            val result = CompletableDeferred<Boolean>()
 
-                        actor.send(LockMsg.IsEmpty(result))
+                            actor.send(LockMsg.IsEmpty(result))
 
-                        val isEmpty = try {
-                            withTimeout(10) {
-                                result.await()
+                            val isEmpty = try {
+                                withTimeout(10) {
+                                    result.await()
+                                }
+                            } catch (e: Exception) {
+                                // 에러에 대한 처리는 따로 하지않음
+                                // 시간 안에 처리 안되면, 작업이 남았다고 간주
+                                false
                             }
-                        } catch (e: Exception) {
-                            // 에러에 대한 처리는 따로 하지않음
-                            // 시간 안에 처리 안되면, 작업이 남았다고 간주
-                            false
+
+                            if (isEmpty) {
+                                // 빔
+                                key
+                            } else {
+                                // 안빔
+                                ""
+                            }
                         }
+                    }.toTypedArray()
 
-                        if (isEmpty) {
-                            key
-                        } else {
-                            ""
-                        }
-                    }
-                }.toTypedArray()
+                    // 빈 actor만 필터링
+                    val emptyKeys = awaitAll(*deferreds).filter { it != "" }
 
-                val emptyKeys = awaitAll(*deferreds).filter { it != "" }
+                    // 빈 actor 삭제
+                    emptyKeys.forEach { key -> actorMap.remove(key) }
+                }
 
-                emptyKeys.forEach { key -> actorMap.remove(key) }
-
-                logger.info { "after ${actorMap}" }
+                logger.info { "after $actorMap" }
             }
         }
     }
 }
 
+/**
+ * render 안하면 잘 보입니다. render 푸세요
+ *
+ * SuspendableLockManager -> LockManagerActor -> LockActor </br>
+ *              ^                   |               |
+ *              |-----------------------------------
+ *
+ * SuspendableLockManager -> LockManagerActor -> LockActor 순서로 메세지가 전달됨
+ *
+ * Deferred에 응답을 채우는 방식으로 LockManagerActor / LockActor 에서 SuspendableLockManager 로 응답이 전달됨
+ * 에러 또한 이 방식으로 전달됨
+ */
 @Component
 class SuspendableLockManager(
     val coroutineExceptionHandler: ErrorPublishingCoroutineExceptionHandler,
 ) : LockManager {
-
     private val actor = lockManagerActor()
 
     override suspend fun <T> lock(key: String, block: suspend () -> T): T {
         val result = CompletableDeferred<Any?>()
-        val now = LocalDateTime.now()
 
+        // 락 시도
         actor.send(
             LockManagerMsg.TryLock(
-                requestTime = now,
-                key = key, block = block,
-                blockResult = result
+                key = key,
+                block = block,
+                result = result
             )
         )
 
         return try {
-            val rtn = result.await()
+            // 서비스 로직 반환값 or 에러
+            val rtn = withTimeout(WAIT_TIME_MILLI + LEASE_TIME_MILLI + 1000) {
+                result.await()
+            }
 
+            // 반환값이 에러면 throw
             if (rtn is Exception) {
                 throw rtn
             }
 
+            // TODO: as T 안하는 방법 찾아서 수정 바람
             rtn as T
         } catch (e: TimeoutCancellationException) {
             // 락 획득 시간 에러 처리
@@ -173,13 +208,21 @@ class SuspendableLockManager(
             // 이외의 에러 처리
             throw e
         }
-
     }
 
+    /**
+     * channel이 빈 엑터 map에서 삭제하는 스케줄러
+     */
     @Scheduled(fixedDelay = 1000 * 60)
-    private fun scheduledClearEmptyActor() =
-        CoroutineScope(Dispatchers.IO + coroutineExceptionHandler.handler).launch { clearEmptyActor() }
+    private fun scheduledClearEmptyActor() {
+        CoroutineScope(Dispatchers.IO + coroutineExceptionHandler.handler).launch {
+            clearEmptyActor()
+        }
+    }
 
+    /**
+     * channel이 빈 엑터 map에서 삭제
+     */
     suspend fun clearEmptyActor() {
         actor.send(LockManagerMsg.ClearActor())
     }

--- a/api/src/main/kotlin/com/oksusu/susu/api/common/lock/SuspendableLockManager.kt
+++ b/api/src/main/kotlin/com/oksusu/susu/api/common/lock/SuspendableLockManager.kt
@@ -104,7 +104,7 @@ private fun lockManagerActor(
                         val actor = actorMap.computeIfAbsent(msg.key) { _ ->
                             lockActor(
                                 waitTimeMilli = waitTimeMilli,
-                                leaseTimeMilli = leaseTimeMilli,
+                                leaseTimeMilli = leaseTimeMilli
                             )
                         }
 
@@ -185,10 +185,10 @@ class SuspendableLockManager(
 ) : LockManager {
     private val actor = lockManagerActor(
         waitTimeMilli = lockConfig.waitTimeMilli,
-        leaseTimeMilli = lockConfig.leaseTimeMilli,
+        leaseTimeMilli = lockConfig.leaseTimeMilli
     )
 
-    override suspend fun <T> lock(key: String, block: suspend () -> T): T {
+    override suspend fun <RETURN> lock(key: String, block: suspend () -> RETURN): RETURN {
         val result = CompletableDeferred<Any?>()
 
         // 락 시도
@@ -211,8 +211,8 @@ class SuspendableLockManager(
                 throw rtn
             }
 
-            // TODO: as T 안하는 방법 찾아서 수정 바람
-            rtn as T
+            // TODO: as RETURN 안하는 방법 찾아서 수정 바람
+            rtn as RETURN
         } catch (e: TimeoutCancellationException) {
             // 락 획득 시간 에러 처리
             throw FailToExecuteException(ErrorCode.LOCK_TIMEOUT_ERROR)

--- a/api/src/main/kotlin/com/oksusu/susu/api/common/lock/SuspendableLockManager.kt
+++ b/api/src/main/kotlin/com/oksusu/susu/api/common/lock/SuspendableLockManager.kt
@@ -1,203 +1,186 @@
 package com.oksusu.susu.api.common.lock
 
+import com.oksusu.susu.client.common.coroutine.ErrorPublishingCoroutineExceptionHandler
 import com.oksusu.susu.common.exception.ErrorCode
 import com.oksusu.susu.common.exception.FailToExecuteException
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.actor
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
-import java.util.LinkedList
-import java.util.concurrent.ConcurrentHashMap
+import java.time.LocalDateTime
 
 private val logger = KotlinLogging.logger { }
 
-private enum class LockReturn {
-    /**
-     * 락 실행
-     */
-    PROCESS_LOCK,
+private const val WAIT_TIME = 1000L
+private const val LEASE_TIME = 3000L
+private const val WAIT_TIME_SECONDS = WAIT_TIME * 1000
+private const val LEASE_TIME_SECONDS = LEASE_TIME * 1000
 
-    /**
-     * 락 해제됨
-     */
-    UNLOCK,
-
-    /**
-     * 등록된 채널 삭제
-     */
-    DELETE_CHANNEL,
-
-    /**
-     * 락 큐가 안비었음
-     */
-    NOT_EMPTY_QUEUE,
-
-    /**
-     * 락 큐가 비었음
-     */
-    EMPTY_QUEUE,
-    ;
-}
 
 private sealed class LockMsg {
     /** 락 획득 시도 */
-    class TryLock(val channel: SendChannel<LockReturn>) : LockMsg()
+    class Lock(
+        val requestTime: LocalDateTime,
+        val block: suspend () -> Any?,
+        val blockResult: CompletableDeferred<Any?>,
+    ) : LockMsg()
 
-    /** 락 해제 */
-    class UnLock(val channel: SendChannel<LockReturn>) : LockMsg()
-
-    /** 등록된 채널 지우기 */
-    class DeleteChannel(val channel: SendChannel<LockReturn>) : LockMsg()
-
-    /** 큐 비었는지 확인 */
-    class CheckQueueEmpty(val channel: SendChannel<LockReturn>) : LockMsg()
+    class IsEmpty(
+        val result: CompletableDeferred<Boolean>,
+    ) : LockMsg()
 }
 
 @OptIn(ObsoleteCoroutinesApi::class)
 private fun lockActor() = CoroutineScope(Dispatchers.IO).actor<LockMsg>(capacity = 1000) {
-    // queue 맨 앞 == 락 설정
-    val lockQueue = LinkedList<SendChannel<LockReturn>>()
+    for (msg in channel) {
+        when (msg) {
+            is LockMsg.Lock -> {
+                if (msg.requestTime.isBefore(LocalDateTime.now().minusSeconds(WAIT_TIME_SECONDS))) {
+                    msg.blockResult.complete(FailToExecuteException(ErrorCode.ACQUIRE_LOCK_TIMEOUT))
+                } else {
+                    try {
+                        withTimeout(LEASE_TIME) {
+                            val rtn = msg.block()
+
+                            msg.blockResult.complete(rtn)
+                        }
+                    } catch (e: TimeoutCancellationException) {
+                        // 락 획득 시간 에러 처리
+                        msg.blockResult.complete(FailToExecuteException(ErrorCode.LOCK_TIMEOUT_ERROR))
+                    } catch (e: Exception) {
+                        // 이외의 에러 처리
+                        msg.blockResult.complete(FailToExecuteException(ErrorCode.FAIL_TO_EXECUTE_LOCK))
+                    }
+                }
+            }
+
+            is LockMsg.IsEmpty -> {
+                msg.result.complete(channel.isEmpty)
+            }
+        }
+    }
+}
+
+private sealed class LockManagerMsg {
+    /** 락 획득 시도 */
+    class TryLock(
+        val requestTime: LocalDateTime,
+        val key: String,
+        val block: suspend () -> Any?,
+        val blockResult: CompletableDeferred<Any?>,
+    ) : LockManagerMsg()
+
+    class ClearActor : LockManagerMsg()
+}
+
+@OptIn(ObsoleteCoroutinesApi::class)
+private fun lockManagerActor() = CoroutineScope(Dispatchers.IO).actor<LockManagerMsg>(capacity = 1000) {
+    val actorMap = HashMap<String, SendChannel<LockMsg>>()
 
     for (msg in channel) {
         when (msg) {
-            is LockMsg.TryLock -> {
-                // 큐에 채널 등록하기
-                lockQueue.offer(msg.channel)
+            is LockManagerMsg.TryLock -> {
+                logger.info { "${msg.requestTime} ${LocalDateTime.now()}" }
+                if (msg.requestTime.isBefore(LocalDateTime.now().minusSeconds(WAIT_TIME_SECONDS))) {
+                    msg.blockResult.complete(FailToExecuteException(ErrorCode.ACQUIRE_LOCK_TIMEOUT))
+                } else {
+                    try {
+                        val actor = actorMap.computeIfAbsent(msg.key) { _ -> lockActor() }
 
-                // 만약 방금 등록한 채널이 큐의 맨 앞이라면 바로 실행
-                if (lockQueue.peek() == msg.channel) {
-                    msg.channel.send(LockReturn.PROCESS_LOCK)
-                }
-            }
-
-            is LockMsg.UnLock -> {
-                // 현재 락을 획득한 채널을 큐에서 삭제
-                lockQueue.poll()
-
-                // 다음 락 획득 대상 notify하기
-                if (lockQueue.peek() != null) {
-                    lockQueue.peek().send(LockReturn.PROCESS_LOCK)
-                }
-
-                // 락 해제 및 큐 삭제 완료 알리기
-                msg.channel.send(LockReturn.UNLOCK)
-            }
-
-            is LockMsg.DeleteChannel -> {
-                if (lockQueue.peek() == msg.channel) {
-                    // 삭제하려는 채널이 큐의 맨 앞일 때, 큐에서 삭제하고 다음꺼 실행
-                    lockQueue.poll()
-                    if (lockQueue.peek() != null) {
-                        lockQueue.peek().send(LockReturn.PROCESS_LOCK)
+                        actor.send(
+                            LockMsg.Lock(
+                                requestTime = LocalDateTime.now(),
+                                block = msg.block,
+                                blockResult = msg.blockResult,
+                            )
+                        )
+                    } catch (e: Exception) {
+                        msg.blockResult.complete(FailToExecuteException(ErrorCode.FAIL_TO_GET_LOCK))
                     }
-                } else {
-                    // 삭제하려는 채널이 큐의 맨 앞이 아닐 때, 큐에서만 삭제
-                    lockQueue.remove(msg.channel)
                 }
-
-                // 삭제 완료 처리 알리기
-                msg.channel.send(LockReturn.DELETE_CHANNEL)
             }
 
-            is LockMsg.CheckQueueEmpty -> {
-                if (lockQueue.peek() == null) {
-                    msg.channel.send(LockReturn.EMPTY_QUEUE)
-                } else {
-                    msg.channel.send(LockReturn.NOT_EMPTY_QUEUE)
-                }
+            is LockManagerMsg.ClearActor -> {
+                logger.info { "before ${actorMap}" }
+
+                val deferreds = actorMap.entries.map { (key, actor) ->
+                    async {
+                        val result = CompletableDeferred<Boolean>()
+
+                        actor.send(LockMsg.IsEmpty(result))
+
+                        val isEmpty = try {
+                            withTimeout(10) {
+                                result.await()
+                            }
+                        } catch (e: Exception) {
+                            // 에러에 대한 처리는 따로 하지않음
+                            // 시간 안에 처리 안되면, 작업이 남았다고 간주
+                            false
+                        }
+
+                        if (isEmpty) {
+                            key
+                        } else {
+                            ""
+                        }
+                    }
+                }.toTypedArray()
+
+                val emptyKeys = awaitAll(*deferreds).filter { it != "" }
+
+                emptyKeys.forEach { key -> actorMap.remove(key) }
+
+                logger.info { "after ${actorMap}" }
             }
         }
     }
 }
 
 @Component
-class SuspendableLockManager : LockManager {
-    companion object {
-        private const val WAIT_TIME = 3000L
-        private const val LEASE_TIME = 3000L
-    }
+class SuspendableLockManager(
+    val coroutineExceptionHandler: ErrorPublishingCoroutineExceptionHandler,
+) : LockManager {
 
-    private val actorMap = ConcurrentHashMap<String, SendChannel<LockMsg>>()
+    private val actor = lockManagerActor()
 
     override suspend fun <T> lock(key: String, block: suspend () -> T): T {
-        // lock 관련 리턴 받을 채널
-        Channel<LockReturn>().run {
-            val channel = this
+        val result = CompletableDeferred<Any?>()
+        val now = LocalDateTime.now()
 
-            // 락 설정
-            val actor = tryLock(key, channel)
+        actor.send(
+            LockManagerMsg.TryLock(
+                requestTime = now,
+                key = key, block = block,
+                blockResult = result
+            )
+        )
 
-            try {
-                // 로직 실행
-                return withTimeout(LEASE_TIME) {
-                    block()
-                }
-            } catch (e: TimeoutCancellationException) {
-                // 락 보유 시간 에러 처리
-                throw FailToExecuteException(ErrorCode.LOCK_TIMEOUT_ERROR)
-            } catch (e: Exception) {
-                // 나머지 에러 처리
-                throw e
-            } finally {
-                // 락 해제
-                releaseLock(actor, channel)
+        return try {
+            val rtn = result.await()
 
-                // 큐가 빈 액터 삭제
-                deleteEmptyQueueActor(channel, key)
-
-                logger.info { actorMap }
-            }
-        }
-    }
-
-    private suspend fun tryLock(key: String, channel: Channel<LockReturn>): SendChannel<LockMsg> {
-        val actor = actorMap.compute(key) { _, value ->
-            val actor = value ?: lockActor()
-
-            runBlocking(Dispatchers.Unconfined) {
-                actor.send(LockMsg.TryLock(channel))
+            if (rtn is Exception) {
+                throw rtn
             }
 
-            actor
-        } ?: throw FailToExecuteException(ErrorCode.FAIL_TO_GET_LOCK)
-
-        try {
-            withTimeout(WAIT_TIME) {
-                channel.receive()
-            }
+            rtn as T
         } catch (e: TimeoutCancellationException) {
             // 락 획득 시간 에러 처리
-            throw FailToExecuteException(ErrorCode.ACQUIRE_LOCK_TIMEOUT)
+            throw FailToExecuteException(ErrorCode.LOCK_TIMEOUT_ERROR)
         } catch (e: Exception) {
-            // 수신 채널 지우기
-            actor.send(LockMsg.DeleteChannel(channel))
-            channel.receive()
-
-            throw FailToExecuteException(ErrorCode.FAIL_TO_EXECUTE_LOCK)
+            // 이외의 에러 처리
+            throw e
         }
 
-        return actor
     }
 
-    private suspend fun releaseLock(actor: SendChannel<LockMsg>, channel: Channel<LockReturn>) {
-        actor.send(LockMsg.UnLock(channel))
-        channel.receive()
-    }
+    @Scheduled(fixedDelay = 1000 * 60)
+    private fun scheduledClearEmptyActor() =
+        CoroutineScope(Dispatchers.IO + coroutineExceptionHandler.handler).launch { clearEmptyActor() }
 
-    private suspend fun deleteEmptyQueueActor(channel: Channel<LockReturn>, key: String) {
-        actorMap.computeIfPresent(key) { _, value ->
-            val rtn = runBlocking(Dispatchers.Unconfined) {
-                value.send(LockMsg.CheckQueueEmpty(channel))
-                channel.receive()
-            }
-
-            if (rtn == LockReturn.EMPTY_QUEUE) {
-                null
-            } else {
-                value
-            }
-        }
+    suspend fun clearEmptyActor() {
+        actor.send(LockManagerMsg.ClearActor())
     }
 }

--- a/api/src/main/kotlin/com/oksusu/susu/api/config/LockConfig.kt
+++ b/api/src/main/kotlin/com/oksusu/susu/api/config/LockConfig.kt
@@ -8,7 +8,7 @@ import kotlin.reflect.full.declaredMemberProperties
 
 @Configuration
 @EnableConfigurationProperties(
-    LockConfig.ActorLockConfig::class,
+    LockConfig.ActorLockConfig::class
 )
 class LockConfig(
     val actorLockConfig: ActorLockConfig,

--- a/api/src/main/kotlin/com/oksusu/susu/api/config/LockConfig.kt
+++ b/api/src/main/kotlin/com/oksusu/susu/api/config/LockConfig.kt
@@ -1,0 +1,29 @@
+package com.oksusu.susu.api.config
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+import kotlin.reflect.full.declaredMemberProperties
+
+@Configuration
+@EnableConfigurationProperties(
+    LockConfig.ActorLockConfig::class,
+)
+class LockConfig(
+    val actorLockConfig: ActorLockConfig,
+) {
+    init {
+        val logger = KotlinLogging.logger { }
+        LockConfig::class.declaredMemberProperties
+            .forEach { config ->
+                logger.info { config.get(this).toString() }
+            }
+    }
+
+    @ConfigurationProperties(prefix = "lock.actor-lock")
+    class ActorLockConfig(
+        val waitTimeMilli: Long,
+        val leaseTimeMilli: Long,
+    )
+}

--- a/api/src/main/resources/config/application.yml
+++ b/api/src/main/resources/config/application.yml
@@ -30,6 +30,12 @@ spring:
       dev: common, domain, client, cache
       prod: common, domain, client, cache
 
+# Lock
+lock:
+  actor-lock:
+    wait-time-milli: 3000
+    lease-time-milli: 3000
+
 # DOCS
 springdoc:
   swagger-ui:

--- a/api/src/test/kotlin/com/oksusu/susu/api/common/lock/SuspendableLockManagerTest.kt
+++ b/api/src/test/kotlin/com/oksusu/susu/api/common/lock/SuspendableLockManagerTest.kt
@@ -54,10 +54,13 @@ class SuspendableLockManagerTest : DescribeSpec({
                 successCount.get() shouldBeEqual CONCURRENT_COUNT.toLong()
             }
 
-            it("여러 쓰레드를 생성해 동작했을 때, 요청에 오랜 시간이 걸린다면 에러가 발생해야한다.") {
+            it("여러 쓰레드를 생성해 동작했을 때, 앞선 요청 처리에 오랜 시간이 걸린다면 에러가 발생해야한다.") {
                 val successCount = AtomicLong()
 
-                executeConcurrency(successCount) {
+                executeConcurrency(
+                    successCount = successCount,
+                    concurrentCount = 500
+                ) {
                     lockManager.lock("1") {
                         countService1.increaseWithDelay500()
                         logger.info { "1 ${countService1.counter}" }
@@ -70,11 +73,13 @@ class SuspendableLockManagerTest : DescribeSpec({
                 successCount.get() shouldBeLessThan CONCURRENT_COUNT.toLong()
             }
 
-
             it("여러 쓰레드를 생성해 동작했을 때, 요청 처리에 시간이 락 획득 시간보다 오래 걸린다면 에러가 발생해야한다.") {
                 val successCount = AtomicLong()
 
-                executeConcurrency(successCount) {
+                executeConcurrency(
+                    successCount = successCount,
+                    concurrentCount = 500
+                ) {
                     lockManager.lock("1") {
                         countService1.increaseWithDelay3000()
                         logger.info { "1 ${countService1.counter}" }
@@ -83,8 +88,8 @@ class SuspendableLockManagerTest : DescribeSpec({
 
                 lockManager.clearEmptyActor()
 
-                countService1.counter shouldBeEqual  0
-                successCount.get() shouldBeEqual  0
+                countService1.counter shouldBeEqual 0
+                successCount.get() shouldBeEqual 0
             }
 
             it("여러 쓰레드를 생성해 동작했을 때, 키 별로 락이 지정되고, 카운트가 올바르게 증가해야한다.") {

--- a/api/src/test/kotlin/com/oksusu/susu/api/common/lock/SuspendableLockManagerTest.kt
+++ b/api/src/test/kotlin/com/oksusu/susu/api/common/lock/SuspendableLockManagerTest.kt
@@ -1,5 +1,6 @@
 package com.oksusu.susu.api.common.lock
 
+import com.oksusu.susu.api.config.LockConfig
 import com.oksusu.susu.api.testExtension.CONCURRENT_COUNT
 import com.oksusu.susu.api.testExtension.THREAD_COUNT
 import com.oksusu.susu.api.testExtension.executeConcurrency
@@ -22,10 +23,14 @@ class SuspendableLockManagerTest : DescribeSpec({
     val logger = KotlinLogging.logger { }
 
     val mockCoroutineExceptionHandler = mockk<ErrorPublishingCoroutineExceptionHandler>()
+    val mockLockConfig = mockk<LockConfig.ActorLockConfig>()
 
     every { mockCoroutineExceptionHandler.handler } returns CoroutineExceptionHandler { _, _ -> }
+    every { mockLockConfig.waitTimeMilli } returns 1000
+    every { mockLockConfig.leaseTimeMilli } returns 3000
 
-    val lockManager = SuspendableLockManager(mockCoroutineExceptionHandler)
+
+    val lockManager = SuspendableLockManager(mockCoroutineExceptionHandler, mockLockConfig)
     val countService1 = CountService()
     val countService2 = CountService()
     val countService3 = CountService()

--- a/api/src/test/kotlin/com/oksusu/susu/api/common/lock/SuspendableLockManagerTest.kt
+++ b/api/src/test/kotlin/com/oksusu/susu/api/common/lock/SuspendableLockManagerTest.kt
@@ -29,7 +29,6 @@ class SuspendableLockManagerTest : DescribeSpec({
     every { mockLockConfig.waitTimeMilli } returns 1000
     every { mockLockConfig.leaseTimeMilli } returns 3000
 
-
     val lockManager = SuspendableLockManager(mockCoroutineExceptionHandler, mockLockConfig)
     val countService1 = CountService()
     val countService2 = CountService()

--- a/api/src/test/kotlin/com/oksusu/susu/api/testExtension/ConcurrencyExtension.kt
+++ b/api/src/test/kotlin/com/oksusu/susu/api/testExtension/ConcurrencyExtension.kt
@@ -9,12 +9,17 @@ import java.util.concurrent.atomic.AtomicLong
 private val logger = KotlinLogging.logger { }
 
 const val THREAD_COUNT = 50
-const val CONCURRENT_COUNT = 1000
+const val CONCURRENT_COUNT = 5000
 
-suspend fun <T> executeConcurrency(successCount: AtomicLong, block: suspend () -> T?) {
-    val executorService = Executors.newFixedThreadPool(THREAD_COUNT)
-    val latch = CountDownLatch(CONCURRENT_COUNT)
-    for (i in 1..CONCURRENT_COUNT) {
+suspend fun <T> executeConcurrency(
+    successCount: AtomicLong,
+    threadCount: Int = THREAD_COUNT,
+    concurrentCount: Int = CONCURRENT_COUNT,
+    block: suspend () -> T?,
+) {
+    val executorService = Executors.newFixedThreadPool(threadCount)
+    val latch = CountDownLatch(concurrentCount)
+    for (i in 1..concurrentCount) {
         executorService.submit {
             try {
                 runBlocking {

--- a/api/src/test/kotlin/com/oksusu/susu/api/testExtension/ConcurrencyExtension.kt
+++ b/api/src/test/kotlin/com/oksusu/susu/api/testExtension/ConcurrencyExtension.kt
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicLong
 private val logger = KotlinLogging.logger { }
 
 const val THREAD_COUNT = 50
-const val CONCURRENT_COUNT = 10000
+const val CONCURRENT_COUNT = 1000
 
 suspend fun <T> executeConcurrency(successCount: AtomicLong, block: suspend () -> T?) {
     val executorService = Executors.newFixedThreadPool(THREAD_COUNT)

--- a/batch/src/main/kotlin/com/oksusu/susu/batch/discord/scheduler/ResendFailedSentDiscordMessageScheduler.kt
+++ b/batch/src/main/kotlin/com/oksusu/susu/batch/discord/scheduler/ResendFailedSentDiscordMessageScheduler.kt
@@ -1,7 +1,6 @@
 package com.oksusu.susu.batch.discord.scheduler
 
 import com.oksusu.susu.batch.discord.job.ResendFailedSentDiscordMessageJob
-import com.oksusu.susu.batch.slack.job.ResendFailedSentSlackMessageJob
 import com.oksusu.susu.client.common.coroutine.ErrorPublishingCoroutineExceptionHandler
 import com.oksusu.susu.common.extension.isProd
 import com.oksusu.susu.common.extension.resolveCancellation

--- a/common/src/main/kotlin/com/oksusu/susu/common/extension/CoroutineExtension.kt
+++ b/common/src/main/kotlin/com/oksusu/susu/common/extension/CoroutineExtension.kt
@@ -31,7 +31,7 @@ suspend fun <T> withJob(
 
 fun mdcCoroutineScope(
     context: CoroutineContext = Dispatchers.IO,
-    traceId: String,
+    traceId: String = MDC.getCopyOfContextMap()?.get(MDC_KEY_TRACE_ID) ?: "",
 ): CoroutineScope {
     val contextMap = MDC.getCopyOfContextMap() ?: emptyMap()
     contextMap.plus(MDC_KEY_TRACE_ID to traceId)

--- a/common/src/main/kotlin/com/oksusu/susu/common/extension/NumberExtension.kt
+++ b/common/src/main/kotlin/com/oksusu/susu/common/extension/NumberExtension.kt
@@ -18,3 +18,7 @@ fun Int.toYearMonth(): String {
 
     return "$year.$month"
 }
+
+fun Long.milliToSec(): Long {
+    return this / 1000
+}


### PR DESCRIPTION
## 작업사항
- 이전 concurrenthashmap에서 처리했던 로직을 새로운 actor를 도입하여 처리했습니다.
- lock이 적용되어야할 로직을 actor 내부에서 처리하도록 변경했습니다.
- 락 획득 여부 판단 기준은 queue의 맨 앞에서 actor 내부에서 실행되는 것으로 변경되었습니다.

## 비고
서비스 로직 실행 후 return 받을 때 제너릭 값이 아니라 Any?로 return 받아서, 강제 형변환을 통해 Any? -> T 로 변경합니다
더 좋은 방법이 있을까요?
